### PR TITLE
Add Tour de France 2026 stage 13 results

### DIFF
--- a/projects/tour-de-france-2026/CHANGELOG.md
+++ b/projects/tour-de-france-2026/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this page are documented here.
 
+## 2026-07-17
+
+### Added
+
+- **Stage 13 result** (Dole → Belfort): Mauro Schmid (Team Jayco AlUla) won a two-up sprint from the breakaway ahead of Harold Tejada (XDS Astana Team), with Tom Pidcock (Q36.5 Pro Cycling) taking third at +2s and vaulting to 4th overall. Jersey standings unchanged at the top: Tadej Pogačar leads yellow and polka-dot, Mads Pedersen leads green, Juan Ayuso leads white.
+
+### Changed
+
+- Added `Team Jayco AlUla` (`JAY`) to the team-name constants for Mauro Schmid's stage 13 win.
+- Footer results note now reads "through Stage 13 · 17 Jul 2026".
+
+### Known limitations
+
+- Results data now covers Stages 1–13; Stage 14 onward has route/profile/notes but no podium or jerseys yet.
+
 ## 2026-07-16
 
 ### Added

--- a/projects/tour-de-france-2026/index.html
+++ b/projects/tour-de-france-2026/index.html
@@ -291,7 +291,7 @@
 
   <footer>
     Distances &amp; profiles: ProCyclingStats / ASO official 2026 route. Terrain classed by total climbing and finish type.<br>
-    Results — stage podium (top 3 + teams) and the four classification leaders (yellow / green / polka-dot / white) — shown for completed stages through Stage 12 · 16 Jul 2026. Sources: Wikipedia (2026 Tour de France), ProCyclingStats &amp; Cyclingnews. Stage 1 was a team time trial, so it has no individual winner — the podium lists teams and their times (Jonas Vingegaard took the first yellow jersey as Visma's best-placed rider).<br>
+    Results — stage podium (top 3 + teams) and the four classification leaders (yellow / green / polka-dot / white) — shown for completed stages through Stage 13 · 17 Jul 2026. Sources: Wikipedia (2026 Tour de France), ProCyclingStats &amp; Cyclingnews. Stage 1 was a team time trial, so it has no individual winner — the podium lists teams and their times (Jonas Vingegaard took the first yellow jersey as Visma's best-placed rider).<br>
     Start times are the official neutral roll-out (départ fictif) per ASO's 2026 pattern, converted from CEST (GMT+2) to Singapore time (GMT+8, +6h): flat/hilly road stages 19:05, mountain stages 18:15, Stage 1 team time trial 23:05, Stage 16 individual time trial first rider 18:30, Paris finale 22:30. Exact times can shift slightly per stage — check letour.fr on the day.
   </footer>
 </div>
@@ -351,7 +351,8 @@ const stages=[
 const UAE='UAE Team Emirates-XRG', VIS='Team Visma | Lease a Bike', SQS='Soudal Quick-Step',
   TRK='Lidl-Trek', ALP='Alpecin-Premier Tech', INE='Ineos Grenadiers', UNO='Uno-X Mobility',
   EFE='EF Education-EasyPost', DEC='Decathlon CMA CGM', AST='XDS Astana Team',
-  LIN='Lotto–Intermarché', Q36='Q36.5 Pro Cycling', MOV='Movistar Team', CAJ='Caja Rural-Seguros RGA';
+  LIN='Lotto–Intermarché', Q36='Q36.5 Pro Cycling', MOV='Movistar Team', CAJ='Caja Rural-Seguros RGA',
+  JAY='Team Jayco AlUla';
 const results={
  1:{tt:true,
   top3:[{name:'Team Visma | Lease a Bike', team:'', gap:'0:00'},{name:'Netcompany Ineos cycling team', team:'', gap:'+0:07'},{name:'UAE Team Emirates XRG', team:'', gap:'+0:11'}],
@@ -377,6 +378,8 @@ const results={
  11:{top3:[{name:'Søren Wærenskjold', team:UNO, gap:'0:00'},{name:'Olav Kooij', team:DEC, gap:'s.t.'},{name:'Jasper Philipsen', team:ALP, gap:'s.t.'}],
   jerseys:{yellow:{name:'Tadej Pogačar',team:UAE}, green:{name:'Mads Pedersen',team:TRK}, polka:{name:'Tadej Pogačar',team:UAE}, white:{name:'Juan Ayuso',team:TRK}}},
  12:{top3:[{name:'Tim Merlier', team:SQS, gap:'0:00'},{name:'Olav Kooij', team:DEC, gap:'s.t.'},{name:'Jasper Philipsen', team:ALP, gap:'s.t.'}],
+  jerseys:{yellow:{name:'Tadej Pogačar',team:UAE}, green:{name:'Mads Pedersen',team:TRK}, polka:{name:'Tadej Pogačar',team:UAE}, white:{name:'Juan Ayuso',team:TRK}}},
+ 13:{top3:[{name:'Mauro Schmid', team:JAY, gap:'0:00'},{name:'Harold Tejada', team:AST, gap:'s.t.'},{name:'Tom Pidcock', team:Q36, gap:'+0:02'}],
   jerseys:{yellow:{name:'Tadej Pogačar',team:UAE}, green:{name:'Mads Pedersen',team:TRK}, polka:{name:'Tadej Pogačar',team:UAE}, white:{name:'Juan Ayuso',team:TRK}}},
 };
 


### PR DESCRIPTION
Mauro Schmid (Jayco AlUla) won the breakaway sprint into Belfort ahead
of Harold Tejada (XDS Astana) and Tom Pidcock (Q36.5), who moved up to
4th overall. Jersey leaders unchanged: Pogačar (yellow/polka), Pedersen
(green), Ayuso (white).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QMTZXipMRrehHkEmc8SFJp