### PR TITLE
Add Stage 14 results to Tour de France 2026 tracker

### DIFF
--- a/projects/tour-de-france-2026/CHANGELOG.md
+++ b/projects/tour-de-france-2026/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this page are documented here.
 
+## 2026-07-19
+
+### Added
+
+- **Stage 14 result** (Mulhouse → Le Markstein): Tadej Pogačar (UAE Team Emirates-XRG) attacked on the Col du Haag inside the final 7km to solo to his fourth stage win of this Tour, 38 seconds ahead of teammate Isaac del Toro and Paul Seixas (Decathlon CMA CGM), who crossed together. Pogačar extends his overall lead and keeps the polka-dot jersey; Paul Seixas takes the white jersey from Juan Ayuso. Mads Pedersen still leads green.
+
+### Changed
+
+- Footer results note now reads "through Stage 14 · 18 Jul 2026".
+
+### Known limitations
+
+- Results data now covers Stages 1–14; Stage 15 onward has route/profile/notes but no podium or jerseys yet.
+
 ## 2026-07-17
 
 ### Added

--- a/projects/tour-de-france-2026/index.html
+++ b/projects/tour-de-france-2026/index.html
@@ -292,7 +292,7 @@
 
   <footer>
     Distances &amp; profiles: ProCyclingStats / ASO official 2026 route. Terrain classed by total climbing and finish type.<br>
-    Results — stage podium (top 3 + teams) and the four classification leaders (yellow / green / polka-dot / white) — shown for completed stages through Stage 13 · 17 Jul 2026. Sources: Wikipedia (2026 Tour de France), ProCyclingStats &amp; Cyclingnews. Stage 1 was a team time trial, so it has no individual winner — the podium lists teams and their times (Jonas Vingegaard took the first yellow jersey as Visma's best-placed rider).<br>
+    Results — stage podium (top 3 + teams) and the four classification leaders (yellow / green / polka-dot / white) — shown for completed stages through Stage 14 · 18 Jul 2026. Sources: Wikipedia (2026 Tour de France), ProCyclingStats &amp; Cyclingnews. Stage 1 was a team time trial, so it has no individual winner — the podium lists teams and their times (Jonas Vingegaard took the first yellow jersey as Visma's best-placed rider).<br>
     Start times are the official neutral roll-out (départ fictif) per ASO's 2026 pattern, converted from CEST (GMT+2) to Singapore time (GMT+8, +6h): flat/hilly road stages 19:05, mountain stages 18:15, Stage 1 team time trial 23:05, Stage 16 individual time trial first rider 18:30, Paris finale 22:30. Exact times can shift slightly per stage — check letour.fr on the day.
   </footer>
 </div>
@@ -382,6 +382,8 @@ const results={
   jerseys:{yellow:{name:'Tadej Pogačar',team:UAE}, green:{name:'Mads Pedersen',team:TRK}, polka:{name:'Tadej Pogačar',team:UAE}, white:{name:'Juan Ayuso',team:TRK}}},
  13:{top3:[{name:'Mauro Schmid', team:JAY, gap:'0:00'},{name:'Harold Tejada', team:AST, gap:'s.t.'},{name:'Tom Pidcock', team:Q36, gap:'+0:02'}],
   jerseys:{yellow:{name:'Tadej Pogačar',team:UAE}, green:{name:'Mads Pedersen',team:TRK}, polka:{name:'Tadej Pogačar',team:UAE}, white:{name:'Juan Ayuso',team:TRK}}},
+ 14:{top3:[{name:'Tadej Pogačar', team:UAE, gap:'0:00'},{name:'Isaac del Toro', team:UAE, gap:'+0:38'},{name:'Paul Seixas', team:DEC, gap:'s.t.'}],
+  jerseys:{yellow:{name:'Tadej Pogačar',team:UAE}, green:{name:'Mads Pedersen',team:TRK}, polka:{name:'Tadej Pogačar',team:UAE}, white:{name:'Paul Seixas',team:DEC}}},
 };
 
 const TERR={


### PR DESCRIPTION
Tadej Pogačar won solo from the Col du Haag ahead of Isaac del Toro
and Paul Seixas, who takes the white jersey from Juan Ayuso. Yellow,
green, and polka-dot jerseys stay with Pogačar/Pedersen/Pogačar.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01R5CpZmWmdoKLVNXKd1TSEb