### PR TITLE
Add Stage 15 results to Tour de France 2026 tracker

### DIFF
--- a/projects/tour-de-france-2026/CHANGELOG.md
+++ b/projects/tour-de-france-2026/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this page are documented here.
 
+## 2026-07-20
+
+### Added
+
+- **Stage 15 result** (Champagnole → Plateau de Solaison): Remco Evenepoel (Soudal Quick-Step) beat Tadej Pogačar in a reduced sprint at the top of the first-ever Tour finish on the Plateau de Solaison, with Isaac del Toro (UAE Team Emirates-XRG) 6 seconds back in third. Jonas Vingegaard abandoned earlier in the stage after a crash that fractured his collarbone. Pogačar keeps yellow and polka-dot, Mads Pedersen still leads green, and Isaac del Toro takes the white jersey from Paul Seixas.
+
+### Changed
+
+- Footer results note now reads "through Stage 15 · 19 Jul 2026".
+
+### Known limitations
+
+- Results data now covers Stages 1–15; Stage 16 onward has route/profile/notes but no podium or jerseys yet.
+
 ## 2026-07-19
 
 ### Added

--- a/projects/tour-de-france-2026/index.html
+++ b/projects/tour-de-france-2026/index.html
@@ -292,7 +292,7 @@
 
   <footer>
     Distances &amp; profiles: ProCyclingStats / ASO official 2026 route. Terrain classed by total climbing and finish type.<br>
-    Results — stage podium (top 3 + teams) and the four classification leaders (yellow / green / polka-dot / white) — shown for completed stages through Stage 14 · 18 Jul 2026. Sources: Wikipedia (2026 Tour de France), ProCyclingStats &amp; Cyclingnews. Stage 1 was a team time trial, so it has no individual winner — the podium lists teams and their times (Jonas Vingegaard took the first yellow jersey as Visma's best-placed rider).<br>
+    Results — stage podium (top 3 + teams) and the four classification leaders (yellow / green / polka-dot / white) — shown for completed stages through Stage 15 · 19 Jul 2026. Sources: Wikipedia (2026 Tour de France), ProCyclingStats &amp; Cyclingnews. Stage 1 was a team time trial, so it has no individual winner — the podium lists teams and their times (Jonas Vingegaard took the first yellow jersey as Visma's best-placed rider).<br>
     Start times are the official neutral roll-out (départ fictif) per ASO's 2026 pattern, converted from CEST (GMT+2) to Singapore time (GMT+8, +6h): flat/hilly road stages 19:05, mountain stages 18:15, Stage 1 team time trial 23:05, Stage 16 individual time trial first rider 18:30, Paris finale 22:30. Exact times can shift slightly per stage — check letour.fr on the day.
   </footer>
 </div>
@@ -384,6 +384,8 @@ const results={
   jerseys:{yellow:{name:'Tadej Pogačar',team:UAE}, green:{name:'Mads Pedersen',team:TRK}, polka:{name:'Tadej Pogačar',team:UAE}, white:{name:'Juan Ayuso',team:TRK}}},
  14:{top3:[{name:'Tadej Pogačar', team:UAE, gap:'0:00'},{name:'Isaac del Toro', team:UAE, gap:'+0:38'},{name:'Paul Seixas', team:DEC, gap:'s.t.'}],
   jerseys:{yellow:{name:'Tadej Pogačar',team:UAE}, green:{name:'Mads Pedersen',team:TRK}, polka:{name:'Tadej Pogačar',team:UAE}, white:{name:'Paul Seixas',team:DEC}}},
+ 15:{top3:[{name:'Remco Evenepoel', team:SQS, gap:'0:00'},{name:'Tadej Pogačar', team:UAE, gap:'s.t.'},{name:'Isaac del Toro', team:UAE, gap:'+0:06'}],
+  jerseys:{yellow:{name:'Tadej Pogačar',team:UAE}, green:{name:'Mads Pedersen',team:TRK}, polka:{name:'Tadej Pogačar',team:UAE}, white:{name:'Isaac del Toro',team:UAE}}},
 };
 
 const TERR={


### PR DESCRIPTION
Remco Evenepoel beat Tadej Pogačar in a sprint atop the Plateau de
Solaison, with Isaac del Toro third. Jonas Vingegaard abandoned after
a crash. Yellow, green, and polka-dot stay with Pogačar/Pedersen/
Pogačar; Isaac del Toro takes the white jersey from Paul Seixas.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UYFETQURt2QKCMrhgEN9PC