### PR TITLE
Add Tour de France 2026 Stage 16 results (ITT)

### DIFF
--- a/projects/tour-de-france-2026/CHANGELOG.md
+++ b/projects/tour-de-france-2026/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this page are documented here.
 
+## 2026-07-21
+
+### Added
+
+- **Stage 16 result** (Évian-les-Bains → Thonon-les-Bains, the race's only individual time trial): Remco Evenepoel (Soudal Quick-Step) obliterated the 26.1 km course in 32'19" to take back-to-back stage wins, beating Tadej Pogačar (UAE Team Emirates-XRG) by 28 seconds and Mattias Skjelmose (Lidl-Trek) by 1'04" in third. Evenepoel trims his GC deficit but Pogačar keeps yellow with a commanding lead. Jerseys unchanged: Pogačar in yellow and polka-dot, Mads Pedersen in green, Isaac del Toro in white.
+
+### Changed
+
+- Footer results note now reads "through Stage 16 · 21 Jul 2026".
+
+### Known limitations
+
+- Results data now covers Stages 1–16; Stage 17 onward has route/profile/notes but no podium or jerseys yet.
+
 ## 2026-07-20
 
 ### Added

--- a/projects/tour-de-france-2026/index.html
+++ b/projects/tour-de-france-2026/index.html
@@ -292,7 +292,7 @@
 
   <footer>
     Distances &amp; profiles: ProCyclingStats / ASO official 2026 route. Terrain classed by total climbing and finish type.<br>
-    Results — stage podium (top 3 + teams) and the four classification leaders (yellow / green / polka-dot / white) — shown for completed stages through Stage 15 · 19 Jul 2026. Sources: Wikipedia (2026 Tour de France), ProCyclingStats &amp; Cyclingnews. Stage 1 was a team time trial, so it has no individual winner — the podium lists teams and their times (Jonas Vingegaard took the first yellow jersey as Visma's best-placed rider).<br>
+    Results — stage podium (top 3 + teams) and the four classification leaders (yellow / green / polka-dot / white) — shown for completed stages through Stage 16 · 21 Jul 2026. Sources: Wikipedia (2026 Tour de France), ProCyclingStats &amp; Cyclingnews. Stage 1 was a team time trial, so it has no individual winner — the podium lists teams and their times (Jonas Vingegaard took the first yellow jersey as Visma's best-placed rider).<br>
     Start times are the official neutral roll-out (départ fictif) per ASO's 2026 pattern, converted from CEST (GMT+2) to Singapore time (GMT+8, +6h): flat/hilly road stages 19:05, mountain stages 18:15, Stage 1 team time trial 23:05, Stage 16 individual time trial first rider 18:30, Paris finale 22:30. Exact times can shift slightly per stage — check letour.fr on the day.
   </footer>
 </div>
@@ -385,6 +385,8 @@ const results={
  14:{top3:[{name:'Tadej Pogačar', team:UAE, gap:'0:00'},{name:'Isaac del Toro', team:UAE, gap:'+0:38'},{name:'Paul Seixas', team:DEC, gap:'s.t.'}],
   jerseys:{yellow:{name:'Tadej Pogačar',team:UAE}, green:{name:'Mads Pedersen',team:TRK}, polka:{name:'Tadej Pogačar',team:UAE}, white:{name:'Paul Seixas',team:DEC}}},
  15:{top3:[{name:'Remco Evenepoel', team:SQS, gap:'0:00'},{name:'Tadej Pogačar', team:UAE, gap:'s.t.'},{name:'Isaac del Toro', team:UAE, gap:'+0:06'}],
+  jerseys:{yellow:{name:'Tadej Pogačar',team:UAE}, green:{name:'Mads Pedersen',team:TRK}, polka:{name:'Tadej Pogačar',team:UAE}, white:{name:'Isaac del Toro',team:UAE}}},
+ 16:{top3:[{name:'Remco Evenepoel', team:SQS, gap:'0:00'},{name:'Tadej Pogačar', team:UAE, gap:'+0:28'},{name:'Mattias Skjelmose', team:TRK, gap:'+1:04'}],
   jerseys:{yellow:{name:'Tadej Pogačar',team:UAE}, green:{name:'Mads Pedersen',team:TRK}, polka:{name:'Tadej Pogačar',team:UAE}, white:{name:'Isaac del Toro',team:UAE}}},
 };
 


### PR DESCRIPTION
## Summary
Updates the Tour de France 2026 stage tracker with results from Stage 16, the race's individual time trial (Évian-les-Bains → Thonon-les-Bains).

## Changes
- **Added Stage 16 podium data**: Remco Evenepoel (Soudal Quick-Step) won the 26.1 km ITT in 32'19", beating Tadej Pogačar by 28 seconds and Mattias Skjelmose by 1'04". Jersey holders remain unchanged (Pogačar yellow/polka-dot, Pedersen green, del Toro white).
- **Updated footer note**: Changed results coverage from "through Stage 15 · 19 Jul 2026" to "through Stage 16 · 21 Jul 2026".
- **Updated CHANGELOG.md**: Added new entry for 2026-07-21 documenting the Stage 16 result, footer change, and noting that results data now covers Stages 1–16 with Stage 17+ having route/profile/notes but no podium/jerseys yet.

## Implementation details
- Stage 16 data follows the existing JSON structure in `index.html`, with top 3 finishers and their time gaps, plus the four classification jersey leaders.
- No changes to the HTML structure or styling; this is purely a data update.

https://claude.ai/code/session_01Hnxfy6jKV6yydDGhdZRrg5