### PR TITLE
Reclassify Tour de France 2026 stage 17 as Flat

### DIFF
--- a/projects/tour-de-france-2026/CHANGELOG.md
+++ b/projects/tour-de-france-2026/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this page are documented here.
 
+## 2026-07-22
+
+### Fixed
+
+- **Stage 17** (Chambéry → Voiron) terrain reclassified from "Hilly" to "Flat" to match the official ASO classification. Updates both the terrain colour code and the stage label; the route note ("Over 2,000 m of climbing but likely the sprinters' last dance") already reflected a sprint-friendly day and is unchanged.
+
 ## 2026-07-21
 
 ### Added

--- a/projects/tour-de-france-2026/index.html
+++ b/projects/tour-de-france-2026/index.html
@@ -334,7 +334,7 @@ const stages=[
  {rest:'Rest day · Monday 20 July'},
  {n:16, type:'ITT', terr:TT, date:'Tue 21 Jul', from:'Évian-les-Bains', to:'Thonon-les-Bains', km:26.1, vm:470, sgt:'18:30', label:'Time trial',
   note:'The Tour\u2019s only <b>individual time trial</b>, along the shore of Lake Geneva. Not pancake-flat — it climbs to the Côte de Larringes early before a flat run-in.'},
- {n:17, type:'Road', terr:H, date:'Wed 22 Jul', from:'Chambéry', to:'Voiron', km:174.7, vm:2362, sgt:'19:05', label:'Hilly',
+ {n:17, type:'Road', terr:F, date:'Wed 22 Jul', from:'Chambéry', to:'Voiron', km:174.7, vm:2362, sgt:'19:05', label:'Flat',
   note:'Over 2,000 m of climbing but likely the sprinters\u2019 last dance, with the Col des Prés and Col de Couz early and a shallow ramp before Voiron.'},
  {n:18, type:'Road', terr:M, date:'Thu 23 Jul', from:'Voiron', to:'Orcières-Merlette', km:185.2, vm:3944, sgt:'18:15', label:'Mountains',
   note:'Into the Alps with a summit finish at Orcières-Merlette — a climb steeped in Tour history.'},


### PR DESCRIPTION
Stage 17 (Chambéry to Voiron) was classified as Hilly but the official
ASO classification is Flat. Update the terrain code and stage label,
and record the change in the project CHANGELOG.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014gSQJRUCUbVD4yxL7v1EAR