### PR TITLE
Add live indicator to current day's stage (Tour de France 2026)

### DIFF
--- a/projects/tour-de-france-2026/index.html
+++ b/projects/tour-de-france-2026/index.html
@@ -184,6 +184,8 @@
   .stage.is-live .todaytag{display:none}
   .stage.is-live .livetag{display:inline-flex}
   .stage.is-live > .stage-btn{border-color:var(--mtn)}
+  /* when expanded, match the drawer's border to the button so the red edge is uniform */
+  .stage.is-live.open .detail{border-color:var(--mtn)}
   @keyframes livePulseRing{
     0%{box-shadow:0 0 0 0 color-mix(in srgb,var(--mtn) 55%,transparent),0 0 0 1.5px var(--mtn)}
     70%{box-shadow:0 0 0 12px color-mix(in srgb,var(--mtn) 0%,transparent),0 0 0 1.5px var(--mtn)}


### PR DESCRIPTION
## Summary

Adds a pulsing "Live" indicator to the current day's stage on the Tour de France 2026 stage tracker (`projects/tour-de-france-2026/`), shown only while the race is actually on.

## What changed

- The current day's stage now shows a **pulsing red "● Live" badge** (replacing the "Today" tag) plus a **soft pulsing red ring** around the card while the race is on.
- The indicator only appears **within 300 minutes (5 hours)** of the stage's official start time — from `start` until `start + 5h` (upper bound exclusive). Outside that window it reverts to the plain "Today" tag with no animation.

## Implementation notes

- Start times on the page are official **Singapore time (GMT+8)**. The live window is computed from an absolute instant built with an explicit `+08:00` offset (`new Date(...T19:05:00+08:00)`), so it's correct regardless of the viewer's own timezone.
- `refreshLive()` toggles an `.is-live` class on the rendered card **without re-rendering**, so open detail drawers and active filters stay put. It runs after each render and on a **30-second interval**, so the badge appears/disappears on its own with no page reload.
- Respects `prefers-reduced-motion` — the badge stays visible but static (no pulsing).
- Fixed a follow-up render issue: when a live stage was expanded, only the button kept a red border while the drawer used the default gray border, making the red edge look thicker at the top. The open drawer's border now matches the button so the red outline is uniform.
- Updated the project's `CHANGELOG.md` under the 2026-07-22 entry, per the project's convention.

## Verification

Rendered in a headless browser with a mocked clock:
- Before start and after the 5-hour mark → no live state, "Today" tag shown.
- Within the 5-hour window → `is-live` active with the red badge + ring.
- Expanded live card → uniform red border around the whole card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bw3ZE1YcGCuVjnjbErA92W