### PR TITLE
Extend live-indicator window to 5 hours (Tour de France 2026)

### DIFF
--- a/projects/tour-de-france-2026/CHANGELOG.md
+++ b/projects/tour-de-france-2026/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this page are documented here.
 
 ### Added
 
-- **Live stage indicator.** The current day's stage now shows a pulsing red "Live" badge (replacing the "Today" tag) and a soft pulsing red ring while the race is on. The indicator only appears within 240 minutes (4 hours) of the stage's official start time — computed from the Singapore-time (GMT+8) start with an explicit `+08:00` offset so the window is correct in any viewer timezone. State is re-evaluated every 30 seconds, so the badge appears and disappears on its own as the window opens and closes without a page reload. Respects `prefers-reduced-motion` (badge stays visible but static, no pulsing).
+- **Live stage indicator.** The current day's stage now shows a pulsing red "Live" badge (replacing the "Today" tag) and a soft pulsing red ring while the race is on. The indicator only appears within 300 minutes (5 hours) of the stage's official start time — computed from the Singapore-time (GMT+8) start with an explicit `+08:00` offset so the window is correct in any viewer timezone. State is re-evaluated every 30 seconds, so the badge appears and disappears on its own as the window opens and closes without a page reload. Respects `prefers-reduced-motion` (badge stays visible but static, no pulsing).
 
 ### Fixed
 

--- a/projects/tour-de-france-2026/index.html
+++ b/projects/tour-de-france-2026/index.html
@@ -463,10 +463,10 @@ function computeTodayStage(){
 const TODAY_N=computeTodayStage();
 
 // Live window: the pulsing "Live" indicator shows on the current day's stage
-// only while we're within LIVE_WINDOW_MIN (240 min = 4 h) of its start time.
+// only while we're within LIVE_WINDOW_MIN (300 min = 5 h) of its start time.
 // Start times are official Singapore time (GMT+8); build an absolute instant
 // with an explicit +08:00 offset so the window is correct in any viewer timezone.
-const LIVE_WINDOW_MIN=240;
+const LIVE_WINDOW_MIN=300;
 function stageStart(s){
   const p=s.date.split(' ');           // e.g. ["Sat","4","Jul"]
   const day=String(+p[1]).padStart(2,'0');


### PR DESCRIPTION
## Summary

Follow-up to #10. Increases the duration of the "Live" indicator on the current day's stage in the Tour de France 2026 stage tracker (`projects/tour-de-france-2026/`) from **4 hours to 5 hours** after the stage start time.

## What changed

- `LIVE_WINDOW_MIN` changed from `240` (4 h) to `300` (5 h). The pulsing red "● Live" badge and ring now remain visible for 5 hours from the stage's official start time instead of 4.
- Updated the accompanying code comment and the `CHANGELOG.md` entry to reflect the 5-hour / 300-minute window.

## Notes

- No behavioral change beyond the window length — the timezone-correct start computation (`+08:00` offset), the 30-second refresh, and the `prefers-reduced-motion` handling are all unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bw3ZE1YcGCuVjnjbErA92W

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bw3ZE1YcGCuVjnjbErA92W)_