### PR TITLE
Add Tour de France 2026 Stage 18 result

### DIFF
--- a/projects/tour-de-france-2026/CHANGELOG.md
+++ b/projects/tour-de-france-2026/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this page are documented here.
 
+## 2026-07-23 (later)
+
+### Added
+
+- **Stage 18 result** (Voiron → Orcières-Merlette): Richard Carapaz (EF Education-EasyPost) rode a masterclass from the day's breakaway, attacking around 3.5 km from the summit to solo to victory 45 seconds ahead of Mauro Schmid (Team Jayco AlUla) and Matteo Jorgenson (Team Visma | Lease a Bike). Jerseys unchanged on the first Alpine day: Tadej Pogačar (UAE Team Emirates-XRG) keeps yellow and polka-dot — though his mountains lead is now just one point over Valentin Paret-Peintre — Mads Pedersen extends green, and Isaac del Toro holds white.
+
+### Changed
+
+- Footer results note now reads "through Stage 18 · 23 Jul 2026".
+
+### Known limitations
+
+- Results data now covers Stages 1–18; Stage 19 onward has route/profile/notes but no podium or jerseys yet.
+
 ## 2026-07-23
 
 ### Added

--- a/projects/tour-de-france-2026/index.html
+++ b/projects/tour-de-france-2026/index.html
@@ -314,7 +314,7 @@
 
   <footer>
     Distances &amp; profiles: ProCyclingStats / ASO official 2026 route. Terrain classed by total climbing and finish type.<br>
-    Results — stage podium (top 3 + teams) and the four classification leaders (yellow / green / polka-dot / white) — shown for completed stages through Stage 17 · 22 Jul 2026. Sources: Wikipedia (2026 Tour de France), ProCyclingStats &amp; Cyclingnews. Stage 1 was a team time trial, so it has no individual winner — the podium lists teams and their times (Jonas Vingegaard took the first yellow jersey as Visma's best-placed rider).<br>
+    Results — stage podium (top 3 + teams) and the four classification leaders (yellow / green / polka-dot / white) — shown for completed stages through Stage 18 · 23 Jul 2026. Sources: Wikipedia (2026 Tour de France), ProCyclingStats &amp; Cyclingnews. Stage 1 was a team time trial, so it has no individual winner — the podium lists teams and their times (Jonas Vingegaard took the first yellow jersey as Visma's best-placed rider).<br>
     Start times are the official neutral roll-out (départ fictif) per ASO's 2026 pattern, converted from CEST (GMT+2) to Singapore time (GMT+8, +6h): flat/hilly road stages 19:05, mountain stages 18:15, Stage 1 team time trial 23:05, Stage 16 individual time trial first rider 18:30, Paris finale 22:30. Exact times can shift slightly per stage — check letour.fr on the day.
   </footer>
 </div>
@@ -411,6 +411,8 @@ const results={
  16:{top3:[{name:'Remco Evenepoel', team:SQS, gap:'0:00'},{name:'Tadej Pogačar', team:UAE, gap:'+0:28'},{name:'Mattias Skjelmose', team:TRK, gap:'+1:04'}],
   jerseys:{yellow:{name:'Tadej Pogačar',team:UAE}, green:{name:'Mads Pedersen',team:TRK}, polka:{name:'Tadej Pogačar',team:UAE}, white:{name:'Isaac del Toro',team:UAE}}},
  17:{top3:[{name:'Jasper Philipsen', team:ALP, gap:'0:00'},{name:'Mauro Schmid', team:JAY, gap:'s.t.'},{name:'Olav Kooij', team:DEC, gap:'s.t.'}],
+  jerseys:{yellow:{name:'Tadej Pogačar',team:UAE}, green:{name:'Mads Pedersen',team:TRK}, polka:{name:'Tadej Pogačar',team:UAE}, white:{name:'Isaac del Toro',team:UAE}}},
+ 18:{top3:[{name:'Richard Carapaz', team:EFE, gap:'0:00'},{name:'Mauro Schmid', team:JAY, gap:'+0:45'},{name:'Matteo Jorgenson', team:VIS, gap:'s.t.'}],
   jerseys:{yellow:{name:'Tadej Pogačar',team:UAE}, green:{name:'Mads Pedersen',team:TRK}, polka:{name:'Tadej Pogačar',team:UAE}, white:{name:'Isaac del Toro',team:UAE}}},
 };
 


### PR DESCRIPTION
Carapaz solos to victory at Orcières-Merlette 45s ahead of Schmid and
Jorgenson; all four jersey holders unchanged (Pogačar yellow/polka-dot,
Pedersen green, del Toro white). Updates the footer results note and
CHANGELOG.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01E1vzThqeir13AwmbynXLD2