### PR TITLE
Add Stage 19 results (Gap → Alpe d'Huez)

### DIFF
--- a/projects/tour-de-france-2026/CHANGELOG.md
+++ b/projects/tour-de-france-2026/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this page are documented here.
 
+## 2026-07-24
+
+### Added
+
+- **Stage 19 result** (Gap → Alpe d'Huez): Tadej Pogačar (UAE Team Emirates-XRG) launched a long-range attack and reeled in the breakaway inside the final two kilometres to win in the yellow jersey — a record-breaking ascent of the 21 hairpins and his first career stage win on Alpe d'Huez. Lenny Martinez (Bahrain Victorious) took second at six seconds and Richard Carapaz (EF Education-EasyPost) third at nine. Carapaz's mountain points prised the polka-dot jersey off Pogačar's shoulders by a single point; Pogačar keeps yellow (now 7:11 clear of Remco Evenepoel), Mads Pedersen holds green and Isaac del Toro white.
+
+### Changed
+
+- Footer results note now reads "through Stage 19 · 24 Jul 2026".
+- Added a `Bahrain Victorious` team constant for Lenny Martinez's podium placing.
+
+### Known limitations
+
+- Results data now covers Stages 1–19; Stage 20 onward has route/profile/notes but no podium or jerseys yet.
+
 ## 2026-07-23 (later)
 
 ### Added

--- a/projects/tour-de-france-2026/index.html
+++ b/projects/tour-de-france-2026/index.html
@@ -314,7 +314,7 @@
 
   <footer>
     Distances &amp; profiles: ProCyclingStats / ASO official 2026 route. Terrain classed by total climbing and finish type.<br>
-    Results — stage podium (top 3 + teams) and the four classification leaders (yellow / green / polka-dot / white) — shown for completed stages through Stage 18 · 23 Jul 2026. Sources: Wikipedia (2026 Tour de France), ProCyclingStats &amp; Cyclingnews. Stage 1 was a team time trial, so it has no individual winner — the podium lists teams and their times (Jonas Vingegaard took the first yellow jersey as Visma's best-placed rider).<br>
+    Results — stage podium (top 3 + teams) and the four classification leaders (yellow / green / polka-dot / white) — shown for completed stages through Stage 19 · 24 Jul 2026. Sources: Wikipedia (2026 Tour de France), ProCyclingStats &amp; Cyclingnews. Stage 1 was a team time trial, so it has no individual winner — the podium lists teams and their times (Jonas Vingegaard took the first yellow jersey as Visma's best-placed rider).<br>
     Start times are the official neutral roll-out (départ fictif) per ASO's 2026 pattern, converted from CEST (GMT+2) to Singapore time (GMT+8, +6h): flat/hilly road stages 19:05, mountain stages 18:15, Stage 1 team time trial 23:05, Stage 16 individual time trial first rider 18:30, Paris finale 22:30. Exact times can shift slightly per stage — check letour.fr on the day.
   </footer>
 </div>
@@ -375,7 +375,7 @@ const UAE='UAE Team Emirates-XRG', VIS='Team Visma | Lease a Bike', SQS='Soudal 
   TRK='Lidl-Trek', ALP='Alpecin-Premier Tech', INE='Ineos Grenadiers', UNO='Uno-X Mobility',
   EFE='EF Education-EasyPost', DEC='Decathlon CMA CGM', AST='XDS Astana Team',
   LIN='Lotto–Intermarché', Q36='Q36.5 Pro Cycling', MOV='Movistar Team', CAJ='Caja Rural-Seguros RGA',
-  JAY='Team Jayco AlUla';
+  JAY='Team Jayco AlUla', BAH='Bahrain Victorious';
 const results={
  1:{tt:true,
   top3:[{name:'Team Visma | Lease a Bike', team:'', gap:'0:00'},{name:'Netcompany Ineos cycling team', team:'', gap:'+0:07'},{name:'UAE Team Emirates XRG', team:'', gap:'+0:11'}],
@@ -414,6 +414,8 @@ const results={
   jerseys:{yellow:{name:'Tadej Pogačar',team:UAE}, green:{name:'Mads Pedersen',team:TRK}, polka:{name:'Tadej Pogačar',team:UAE}, white:{name:'Isaac del Toro',team:UAE}}},
  18:{top3:[{name:'Richard Carapaz', team:EFE, gap:'0:00'},{name:'Mauro Schmid', team:JAY, gap:'+0:45'},{name:'Matteo Jorgenson', team:VIS, gap:'s.t.'}],
   jerseys:{yellow:{name:'Tadej Pogačar',team:UAE}, green:{name:'Mads Pedersen',team:TRK}, polka:{name:'Tadej Pogačar',team:UAE}, white:{name:'Isaac del Toro',team:UAE}}},
+ 19:{top3:[{name:'Tadej Pogačar', team:UAE, gap:'0:00'},{name:'Lenny Martinez', team:BAH, gap:'+0:06'},{name:'Richard Carapaz', team:EFE, gap:'+0:09'}],
+  jerseys:{yellow:{name:'Tadej Pogačar',team:UAE}, green:{name:'Mads Pedersen',team:TRK}, polka:{name:'Richard Carapaz',team:EFE}, white:{name:'Isaac del Toro',team:UAE}}},
 };
 
 const TERR={


### PR DESCRIPTION
## Summary
Updates the Tour de France 2026 tracker with Stage 19 results from the Gap → Alpe d'Huez mountain stage, including podium finishers, jersey changes, and supporting documentation.

## Changes
- **Added Stage 19 results data**: Tadej Pogačar (UAE Team Emirates-XRG) won the stage; Lenny Martinez (Bahrain Victorious) placed second (+0:06); Richard Carapaz (EF Education-EasyPost) placed third (+0:09)
- **Updated classification leaders**: Richard Carapaz took the polka-dot jersey from Pogačar by one point; yellow, green, and white jerseys remain unchanged
- **Added `Bahrain Victorious` team constant** (`BAH`) to support Lenny Martinez's podium entry
- **Updated footer note**: Changed results coverage from "through Stage 18 · 23 Jul 2026" to "through Stage 19 · 24 Jul 2026"
- **Updated CHANGELOG.md**: Documented the stage result, jersey changes, and noted that Stage 20+ has route/profile data but no results yet

## Implementation details
- Stage 19 data follows the existing results object structure with `top3` array and `jerseys` object
- Pogačar's stage win is his first career victory on Alpe d'Huez, achieved via a long-range attack in the final two kilometres
- Yellow jersey gap widened to 7:11 over Remco Evenepoel

https://claude.ai/code/session_01JbVbGiNj8A4chQZ5vF5z4e