### PR TITLE
Add Tour de France 2026 stage 20 result

### DIFF
--- a/projects/tour-de-france-2026/CHANGELOG.md
+++ b/projects/tour-de-france-2026/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this page are documented here.
 
+## 2026-07-25
+
+### Added
+
+- **Stage 20 result** (Le Bourg-d'Oisans → Alpe d'Huez, the queen stage): Richard Carapaz (EF Education-EasyPost) won back-to-back Alpe d'Huez stages, going clear from the day's breakaway and taking maximum points on three of the four classified climbs. Sepp Kuss (Team Visma | Lease a Bike) was alone in front inside the final 10 km but crashed twice — once at the exit of a tunnel, once on a descent — letting Carapaz through to a solo win in 4h 59' 39". Remco Evenepoel (Red Bull–BORA–hansgrohe) caught and passed Kuss in the final 500 m to take second at 26 seconds, with Kuss third at 31. Tadej Pogačar spent the last third of the stage pacing teammate Isaac del Toro, the pair finishing 4th and 5th at 1'05"; Pogačar keeps yellow, now 6:26 ahead of Evenepoel. Carapaz's haul puts the mountains classification mathematically out of reach (56 points clear of Pogačar), Mads Pedersen holds green and del Toro white.
+
+### Changed
+
+- Footer results note now reads "through Stage 20 · 25 Jul 2026".
+
+### Fixed
+
+- **Remco Evenepoel's team corrected** from `Soudal Quick-Step` to `Red Bull–BORA–hansgrohe` across Stages 2, 10, 15 and 16. He left Soudal Quick-Step at the end of 2025 and rides the 2026 Tour for Red Bull–BORA–hansgrohe; the old value was carried over from his 2024–25 team. Added a `RBH` team constant. Soudal Quick-Step remains correct for Tim Merlier's stage wins.
+
+### Known limitations
+
+- Results data now covers Stages 1–20; only Stage 21 (the Paris finale) has route/profile/notes but no podium or jerseys yet.
+
 ## 2026-07-24
 
 ### Added

--- a/projects/tour-de-france-2026/index.html
+++ b/projects/tour-de-france-2026/index.html
@@ -314,7 +314,7 @@
 
   <footer>
     Distances &amp; profiles: ProCyclingStats / ASO official 2026 route. Terrain classed by total climbing and finish type.<br>
-    Results — stage podium (top 3 + teams) and the four classification leaders (yellow / green / polka-dot / white) — shown for completed stages through Stage 19 · 24 Jul 2026. Sources: Wikipedia (2026 Tour de France), ProCyclingStats &amp; Cyclingnews. Stage 1 was a team time trial, so it has no individual winner — the podium lists teams and their times (Jonas Vingegaard took the first yellow jersey as Visma's best-placed rider).<br>
+    Results — stage podium (top 3 + teams) and the four classification leaders (yellow / green / polka-dot / white) — shown for completed stages through Stage 20 · 25 Jul 2026. Sources: Wikipedia (2026 Tour de France), ProCyclingStats &amp; Cyclingnews. Stage 1 was a team time trial, so it has no individual winner — the podium lists teams and their times (Jonas Vingegaard took the first yellow jersey as Visma's best-placed rider).<br>
     Start times are the official neutral roll-out (départ fictif) per ASO's 2026 pattern, converted from CEST (GMT+2) to Singapore time (GMT+8, +6h): flat/hilly road stages 19:05, mountain stages 18:15, Stage 1 team time trial 23:05, Stage 16 individual time trial first rider 18:30, Paris finale 22:30. Exact times can shift slightly per stage — check letour.fr on the day.
   </footer>
 </div>
@@ -375,12 +375,12 @@ const UAE='UAE Team Emirates-XRG', VIS='Team Visma | Lease a Bike', SQS='Soudal 
   TRK='Lidl-Trek', ALP='Alpecin-Premier Tech', INE='Ineos Grenadiers', UNO='Uno-X Mobility',
   EFE='EF Education-EasyPost', DEC='Decathlon CMA CGM', AST='XDS Astana Team',
   LIN='Lotto–Intermarché', Q36='Q36.5 Pro Cycling', MOV='Movistar Team', CAJ='Caja Rural-Seguros RGA',
-  JAY='Team Jayco AlUla', BAH='Bahrain Victorious';
+  JAY='Team Jayco AlUla', BAH='Bahrain Victorious', RBH='Red Bull–BORA–hansgrohe';
 const results={
  1:{tt:true,
   top3:[{name:'Team Visma | Lease a Bike', team:'', gap:'0:00'},{name:'Netcompany Ineos cycling team', team:'', gap:'+0:07'},{name:'UAE Team Emirates XRG', team:'', gap:'+0:11'}],
   jerseys:{yellow:{name:'Jonas Vingegaard',team:VIS}, green:{name:'Egan Bernal',team:INE}, polka:{name:'Tadej Pogačar',team:UAE}, white:{name:'Juan Ayuso',team:TRK}}},
- 2:{top3:[{name:'Isaac del Toro', team:UAE, gap:'0:00'},{name:'Tadej Pogačar', team:UAE, gap:'s.t.'},{name:'Remco Evenepoel', team:SQS, gap:'s.t.'}],
+ 2:{top3:[{name:'Isaac del Toro', team:UAE, gap:'0:00'},{name:'Tadej Pogačar', team:UAE, gap:'s.t.'},{name:'Remco Evenepoel', team:RBH, gap:'s.t.'}],
   jerseys:{yellow:{name:'Isaac del Toro',team:UAE}, green:{name:'Isaac del Toro',team:UAE}, polka:{name:'Alex Molenaar',team:CAJ}, white:{name:'Isaac del Toro',team:UAE}}},
  3:{top3:[{name:'Tadej Pogačar', team:UAE, gap:'0:00'},{name:'Jonas Vingegaard', team:VIS, gap:'+0:02'},{name:'Richard Carapaz', team:EFE, gap:''}],
   jerseys:{yellow:{name:'Tadej Pogačar',team:UAE}, green:{name:'Tadej Pogačar',team:UAE}, polka:{name:'Tadej Pogačar',team:UAE}, white:{name:'Alex Baudin',team:EFE}}},
@@ -396,7 +396,7 @@ const results={
   jerseys:{yellow:{name:'Tadej Pogačar',team:UAE}, green:{name:'Mads Pedersen',team:TRK}, polka:{name:'Tadej Pogačar',team:UAE}, white:{name:'Isaac del Toro',team:UAE}}},
  9:{top3:[{name:'Mathieu van der Poel', team:ALP, gap:'0:00'},{name:'Tobias Halland Johannessen', team:UNO, gap:'s.t.'},{name:'Tom Pidcock', team:Q36, gap:'s.t.'}],
   jerseys:{yellow:{name:'Tadej Pogačar',team:UAE}, green:{name:'Mathieu van der Poel',team:ALP}, polka:{name:'Tadej Pogačar',team:UAE}, white:{name:'Isaac del Toro',team:UAE}}},
- 10:{top3:[{name:'Tadej Pogačar', team:UAE, gap:'0:00'},{name:'Remco Evenepoel', team:SQS, gap:'+0:32'},{name:'Paul Seixas', team:DEC, gap:'+0:34'}],
+ 10:{top3:[{name:'Tadej Pogačar', team:UAE, gap:'0:00'},{name:'Remco Evenepoel', team:RBH, gap:'+0:32'},{name:'Paul Seixas', team:DEC, gap:'+0:34'}],
   jerseys:{yellow:{name:'Tadej Pogačar',team:UAE}, green:{name:'Mads Pedersen',team:TRK}, polka:{name:'Tadej Pogačar',team:UAE}, white:{name:'Isaac del Toro',team:UAE}}},
  11:{top3:[{name:'Søren Wærenskjold', team:UNO, gap:'0:00'},{name:'Olav Kooij', team:DEC, gap:'s.t.'},{name:'Jasper Philipsen', team:ALP, gap:'s.t.'}],
   jerseys:{yellow:{name:'Tadej Pogačar',team:UAE}, green:{name:'Mads Pedersen',team:TRK}, polka:{name:'Tadej Pogačar',team:UAE}, white:{name:'Juan Ayuso',team:TRK}}},
@@ -406,15 +406,17 @@ const results={
   jerseys:{yellow:{name:'Tadej Pogačar',team:UAE}, green:{name:'Mads Pedersen',team:TRK}, polka:{name:'Tadej Pogačar',team:UAE}, white:{name:'Juan Ayuso',team:TRK}}},
  14:{top3:[{name:'Tadej Pogačar', team:UAE, gap:'0:00'},{name:'Isaac del Toro', team:UAE, gap:'+0:38'},{name:'Paul Seixas', team:DEC, gap:'s.t.'}],
   jerseys:{yellow:{name:'Tadej Pogačar',team:UAE}, green:{name:'Mads Pedersen',team:TRK}, polka:{name:'Tadej Pogačar',team:UAE}, white:{name:'Paul Seixas',team:DEC}}},
- 15:{top3:[{name:'Remco Evenepoel', team:SQS, gap:'0:00'},{name:'Tadej Pogačar', team:UAE, gap:'s.t.'},{name:'Isaac del Toro', team:UAE, gap:'+0:06'}],
+ 15:{top3:[{name:'Remco Evenepoel', team:RBH, gap:'0:00'},{name:'Tadej Pogačar', team:UAE, gap:'s.t.'},{name:'Isaac del Toro', team:UAE, gap:'+0:06'}],
   jerseys:{yellow:{name:'Tadej Pogačar',team:UAE}, green:{name:'Mads Pedersen',team:TRK}, polka:{name:'Tadej Pogačar',team:UAE}, white:{name:'Isaac del Toro',team:UAE}}},
- 16:{top3:[{name:'Remco Evenepoel', team:SQS, gap:'0:00'},{name:'Tadej Pogačar', team:UAE, gap:'+0:28'},{name:'Mattias Skjelmose', team:TRK, gap:'+1:04'}],
+ 16:{top3:[{name:'Remco Evenepoel', team:RBH, gap:'0:00'},{name:'Tadej Pogačar', team:UAE, gap:'+0:28'},{name:'Mattias Skjelmose', team:TRK, gap:'+1:04'}],
   jerseys:{yellow:{name:'Tadej Pogačar',team:UAE}, green:{name:'Mads Pedersen',team:TRK}, polka:{name:'Tadej Pogačar',team:UAE}, white:{name:'Isaac del Toro',team:UAE}}},
  17:{top3:[{name:'Jasper Philipsen', team:ALP, gap:'0:00'},{name:'Mauro Schmid', team:JAY, gap:'s.t.'},{name:'Olav Kooij', team:DEC, gap:'s.t.'}],
   jerseys:{yellow:{name:'Tadej Pogačar',team:UAE}, green:{name:'Mads Pedersen',team:TRK}, polka:{name:'Tadej Pogačar',team:UAE}, white:{name:'Isaac del Toro',team:UAE}}},
  18:{top3:[{name:'Richard Carapaz', team:EFE, gap:'0:00'},{name:'Mauro Schmid', team:JAY, gap:'+0:45'},{name:'Matteo Jorgenson', team:VIS, gap:'s.t.'}],
   jerseys:{yellow:{name:'Tadej Pogačar',team:UAE}, green:{name:'Mads Pedersen',team:TRK}, polka:{name:'Tadej Pogačar',team:UAE}, white:{name:'Isaac del Toro',team:UAE}}},
  19:{top3:[{name:'Tadej Pogačar', team:UAE, gap:'0:00'},{name:'Lenny Martinez', team:BAH, gap:'+0:06'},{name:'Richard Carapaz', team:EFE, gap:'+0:09'}],
+  jerseys:{yellow:{name:'Tadej Pogačar',team:UAE}, green:{name:'Mads Pedersen',team:TRK}, polka:{name:'Richard Carapaz',team:EFE}, white:{name:'Isaac del Toro',team:UAE}}},
+ 20:{top3:[{name:'Richard Carapaz', team:EFE, gap:'0:00'},{name:'Remco Evenepoel', team:RBH, gap:'+0:26'},{name:'Sepp Kuss', team:VIS, gap:'+0:31'}],
   jerseys:{yellow:{name:'Tadej Pogačar',team:UAE}, green:{name:'Mads Pedersen',team:TRK}, polka:{name:'Richard Carapaz',team:EFE}, white:{name:'Isaac del Toro',team:UAE}}},
 };
 


### PR DESCRIPTION
Stage 20 (Le Bourg-d'Oisans -> Alpe d'Huez, the queen stage): Richard
Carapaz (EF Education-EasyPost) soloed to a second straight Alpe d'Huez
win after Sepp Kuss crashed twice inside the final 10 km. Remco Evenepoel
second at +0:26, Kuss third at +0:31. Jerseys unchanged: Pogacar yellow,
Pedersen green, Carapaz polka-dot (now mathematically secured), del Toro
white.

Also corrects Remco Evenepoel's team from Soudal Quick-Step to
Red Bull-BORA-hansgrohe on stages 2, 10, 15 and 16 - he moved teams for
the 2026 season - and updates the footer note and CHANGELOG.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KWFGJpc12bXB1NSL54W6jV