### PR TITLE
Update Tour de France stage 21 for shortened Paris finale

### DIFF
--- a/projects/tour-de-france-2026/CHANGELOG.md
+++ b/projects/tour-de-france-2026/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this page are documented here.
 
+## 2026-07-26
+
+### Changed
+
+- **Stage 21 shortened from 133 km to 89 km.** Wildfires around Arcachon Bay (Gironde) and Biscarrosse (Landes) have burned more than 36,000 hectares, and the interior ministry redeployed the police originally mobilised for the race, so ASO cancelled the Thoiry start. The teams are still presented in Thoiry, then bussed to Paris for a real start on the Champs-Élysées, with two extra laps of the avenue added ahead of the three Montmartre ascents, which are unchanged (the last crests 10.3 km from the line).
+  - Route now reads `Paris → Paris` instead of `Thoiry → Paris`.
+  - Distance `133` → `89` km; total climbing `1,295` → `1,000` m.
+  - Start time `22:30` → `23:50` SGT (17:50 CEST, 1h20 later than planned).
+  - Stage note rewritten to explain the change.
+- Header total distance `3,290 km` → `3,246 km`, with a footer line recording the original figure and why it changed.
+- Footer start-times note: the Paris finale entry now gives the revised 23:50 start and flags that, with no neutral transfer left, it is the real start rather than a *départ fictif*.
+
+### Known limitations
+
+- Results data still covers Stages 1–20; Stage 21 has route/profile/notes but no podium or jerseys until the finale is run.
+- The 1,000 m climbing figure for the revised Stage 21 is the rounded number being quoted in previews of the new route, not an ASO-published profile — treat it as approximate.
+
 ## 2026-07-25
 
 ### Added

--- a/projects/tour-de-france-2026/index.html
+++ b/projects/tour-de-france-2026/index.html
@@ -293,7 +293,7 @@
     </div>
     <div class="stats">
       <div class="stat"><div class="n">21</div><div class="l">Stages</div></div>
-      <div class="stat"><div class="n">3,290<span style="font-size:14px"> km</span></div><div class="l">Total distance</div></div>
+      <div class="stat"><div class="n">3,246<span style="font-size:14px"> km</span></div><div class="l">Total distance</div></div>
       <div class="stat"><div class="n">8</div><div class="l">Mountain stages</div></div>
       <div class="stat"><div class="n">2</div><div class="l">Time trials</div></div>
       <div class="stat"><div class="n">2</div><div class="l">Rest days</div></div>
@@ -313,9 +313,9 @@
   <div class="empty" id="empty">No stages match that terrain.</div>
 
   <footer>
-    Distances &amp; profiles: ProCyclingStats / ASO official 2026 route. Terrain classed by total climbing and finish type.<br>
+    Distances &amp; profiles: ProCyclingStats / ASO official 2026 route. Terrain classed by total climbing and finish type. Stage 21 was cut from 133 km to 89 km on 25 Jul when ASO moved the start from Thoiry to the Champs-Élysées, so the total distance is now 3,246 km rather than the 3,290 km originally rolled out.<br>
     Results — stage podium (top 3 + teams) and the four classification leaders (yellow / green / polka-dot / white) — shown for completed stages through Stage 20 · 25 Jul 2026. Sources: Wikipedia (2026 Tour de France), ProCyclingStats &amp; Cyclingnews. Stage 1 was a team time trial, so it has no individual winner — the podium lists teams and their times (Jonas Vingegaard took the first yellow jersey as Visma's best-placed rider).<br>
-    Start times are the official neutral roll-out (départ fictif) per ASO's 2026 pattern, converted from CEST (GMT+2) to Singapore time (GMT+8, +6h): flat/hilly road stages 19:05, mountain stages 18:15, Stage 1 team time trial 23:05, Stage 16 individual time trial first rider 18:30, Paris finale 22:30. Exact times can shift slightly per stage — check letour.fr on the day.
+    Start times are the official neutral roll-out (départ fictif) per ASO's 2026 pattern, converted from CEST (GMT+2) to Singapore time (GMT+8, +6h): flat/hilly road stages 19:05, mountain stages 18:15, Stage 1 team time trial 23:05, Stage 16 individual time trial first rider 18:30. The Paris finale was scheduled for 22:30 but now starts at 23:50 (17:50 CEST) on the Champs-Élysées after the route was shortened; with no neutral transfer left, that is the real start. Exact times can shift slightly per stage — check letour.fr on the day.
   </footer>
 </div>
 
@@ -364,8 +364,8 @@ const stages=[
   note:'Short, punchy, and explosive — the first of back-to-back Alpe d\u2019Huez finishes via the traditional 21 hairpins.'},
  {n:20, type:'Road', terr:M, date:'Sat 25 Jul', from:'Le Bourg-d\u2019Oisans', to:'Alpe d\u2019Huez', km:170.9, vm:5624, sgt:'18:15', label:'Mountains',
   note:'The <b>queen stage.</b> Croix de Fer, Télégraphe, Galibier (2,642 m — the Tour\u2019s roof) and Col de Sarenne before a second summit at Alpe d\u2019Huez. 5,600 m of climbing.'},
- {n:21, type:'Road', terr:F, date:'Sun 26 Jul', from:'Thoiry', to:'Paris', km:133, vm:1295, sgt:'22:30', label:'Flat',
-  note:'The finale to the Champs-Élysées, with three ascents of the Montmartre climb from the 2024 Olympics before the run to the line.'},
+ {n:21, type:'Road', terr:F, date:'Sun 26 Jul', from:'Paris', to:'Paris', km:89, vm:1000, sgt:'23:50', label:'Flat',
+  note:'<b>Shortened from 133 km to 89 km.</b> With police redeployed to the wildfires burning around Arcachon Bay and Biscarrosse, ASO scrapped the Thoiry start: the teams are still presented there, then bussed to Paris for a real start on the Champs-Élysées, an hour and twenty minutes later than planned. Two extra laps of the avenue are added, and all three ascents of the Montmartre climb from the 2024 Olympics survive — the last cresting 10.3 km from the line.'},
 ];
 
 // Race results for completed stages (sources: Wikipedia 2026 Tour de France, ProCyclingStats, Cyclingnews).


### PR DESCRIPTION
Wildfires around Arcachon Bay and Biscarrosse pulled the police away
from race security, so ASO cancelled the Thoiry start and moved the
real start onto the Champs-Élysées.

- Stage 21: Thoiry → Paris becomes Paris → Paris, 133 km → 89 km,
  climbing 1,295 m → 1,000 m, start 22:30 → 23:50 SGT (17:50 CEST)
- Rewrite the stage note to explain the cut route: two extra laps of
  the Champs-Élysées, three Montmartre ascents unchanged
- Header total distance 3,290 km → 3,246 km, with footer notes
  recording the original figures and the revised start time
- Log the change in CHANGELOG.md

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Anpht3695eHzf8UZHhgNsU